### PR TITLE
Increase read timeout from 5s to 15s. Decreasing retransmission queue

### DIFF
--- a/src/main/java/com/stackify/api/common/http/HttpClient.java
+++ b/src/main/java/com/stackify/api/common/http/HttpClient.java
@@ -44,7 +44,7 @@ public class HttpClient {
 	/**
 	 * READ_TIMEOUT
 	 */
-	private static final int READ_TIMEOUT = 5000;
+	private static final int READ_TIMEOUT = 15000;
 	
 	/**
 	 * API configuration

--- a/src/main/java/com/stackify/api/common/http/HttpResendQueueItem.java
+++ b/src/main/java/com/stackify/api/common/http/HttpResendQueueItem.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015 Stackify
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stackify.api.common.http;
+
+/**
+ * HttpResendQueueItem
+ * @author Eric Martin
+ */
+public class HttpResendQueueItem {
+
+	/**
+	 * JSON bytes
+	 */
+	private final byte[] jsonBytes;
+	
+	/**
+	 * Number of failures for the item;
+	 */
+	private int numFailures;
+	
+	/**
+	 * Constructor
+	 * @param jsonBytes JSON bytes
+	 */
+	public HttpResendQueueItem(final byte[] jsonBytes) {
+		this.jsonBytes = jsonBytes;
+		this.numFailures = 1;
+	}
+
+	/**
+	 * @return the jsonBytes
+	 */
+	public byte[] getJsonBytes() {
+		return jsonBytes;
+	}
+
+	/**
+	 * @return the numFailures
+	 */
+	public int getNumFailures() {
+		return numFailures;
+	}
+	
+	/**
+	 * Increment the number of failures
+	 */
+	public void failed() {
+		++numFailures;
+	}
+}

--- a/src/main/java/com/stackify/api/common/log/LogAppender.java
+++ b/src/main/java/com/stackify/api/common/log/LogAppender.java
@@ -33,6 +33,11 @@ import com.stackify.api.common.util.Preconditions;
 public class LogAppender<T> implements Closeable {
 
 	/**
+	 * Internal package prefix
+	 */
+	private static final String COM_DOT_STACKIFY = "com.stackify.";
+	
+	/**
 	 * Logger project name
 	 */
 	private final String logger;
@@ -132,7 +137,7 @@ public class LogAppender<T> implements Closeable {
 		String className = eventAdapter.getClassName(event);
 		
 		if (className != null) {
-			if (className.startsWith("com.stackify.api.")) {
+			if (className.startsWith(COM_DOT_STACKIFY)) {
 				return;
 			}
 		}

--- a/src/main/java/com/stackify/api/common/log/LogSender.java
+++ b/src/main/java/com/stackify/api/common/log/LogSender.java
@@ -56,9 +56,9 @@ public class LogSender {
 	private final ObjectMapper objectMapper;
 	
 	/**
-	 * The queue of requests to be retransmitted (max of 100 batches of 100 messages)
+	 * The queue of requests to be retransmitted (max of 20 batches of 100 messages)
 	 */
-	private final HttpResendQueue resendQueue = new HttpResendQueue(100); 
+	private final HttpResendQueue resendQueue = new HttpResendQueue(20); 
 
 	/**
 	 * Default constructor

--- a/src/test/java/com/stackify/api/common/http/HttpResendQueueItemTest.java
+++ b/src/test/java/com/stackify/api/common/http/HttpResendQueueItemTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015 Stackify
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stackify.api.common.http;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * HttpResendQueueItem JUnit Test
+ * @author Eric Martin
+ */
+public class HttpResendQueueItemTest {
+
+	/**
+	 * testConstrcutorAndGetters
+	 */
+	@Test
+	public void testConstrcutorAndGetters() {
+		byte[] jsonBytes = "{\"method\": \"testConstrcutorAndGetters\"}".getBytes();
+		
+		HttpResendQueueItem item = new HttpResendQueueItem(jsonBytes);
+		Assert.assertNotNull(item);
+		
+		Assert.assertEquals(jsonBytes, item.getJsonBytes());
+		Assert.assertEquals(1, item.getNumFailures());
+	}
+	
+	/**
+	 * testIncrementFailures
+	 */
+	@Test
+	public void testIncrementFailures() {
+		byte[] jsonBytes = "{\"method\": \"testIncrementRetries\"}".getBytes();
+		
+		HttpResendQueueItem item = new HttpResendQueueItem(jsonBytes);
+		Assert.assertEquals(1, item.getNumFailures());
+		
+		item.failed();
+		Assert.assertEquals(2, item.getNumFailures());
+		
+		item.failed();
+		Assert.assertEquals(3, item.getNumFailures());
+	}
+}

--- a/src/test/java/com/stackify/api/common/http/HttpResendQueueTest.java
+++ b/src/test/java/com/stackify/api/common/http/HttpResendQueueTest.java
@@ -112,4 +112,27 @@ public class HttpResendQueueTest {
 
 		Assert.assertEquals(0, resendQueue.size());
 	}
+	
+	/**
+	 * testDrainWithExceptionAndSkip
+	 * @throws Exception 
+	 */
+	@Test
+	public void testDrainWithExceptionAndSkip() throws Exception {
+		byte[] request1 = new byte[]{1};
+		
+		HttpResendQueue resendQueue = new HttpResendQueue(3);
+		resendQueue.offer(request1, new IOException());
+		
+		Assert.assertEquals(1, resendQueue.size());
+		
+		HttpClient httpClient = Mockito.mock(HttpClient.class);
+		Mockito.when(httpClient.post("/path", request1, false)).thenThrow(new RuntimeException());
+		
+		resendQueue.drain(httpClient, "/path");
+		Assert.assertEquals(1, resendQueue.size());
+		
+		resendQueue.drain(httpClient, "/path");
+		Assert.assertEquals(0, resendQueue.size());
+	}
 }


### PR DESCRIPTION
from 100 requests to 20 requests. Skip retransmission item after three failures.